### PR TITLE
Fixing Console Printing in Quiet Mode

### DIFF
--- a/src/component_cache.cpp
+++ b/src/component_cache.cpp
@@ -49,14 +49,16 @@ uint64_t freeram() {
 #include "stack.h"
 
 
-ComponentCache::ComponentCache(DataAndStatistics &statistics) :
-		statistics_(statistics) {
+ComponentCache::ComponentCache(DataAndStatistics &statistics,
+                               SolverConfiguration& config) :
+		statistics_(statistics), config_(config) {
 }
 
 void ComponentCache::init(Component &super_comp) {
 
+  if(!config_.quiet)
     cout << sizeof(CacheableComponent) << " " << sizeof(mpz_class) << endl;
-    CacheableComponent &packed_super_comp = *new CacheableComponent(super_comp);
+  CacheableComponent &packed_super_comp = *new CacheableComponent(super_comp);
 	my_time_ = 1;
 
 	entry_base_.clear();
@@ -76,14 +78,14 @@ void ComponentCache::init(Component &super_comp) {
 	  statistics_.maximum_cache_size_bytes_ = max_cache_bound;
 	}
 
-	if (statistics_.maximum_cache_size_bytes_ > free_ram) {
+	if (!config_.quiet && statistics_.maximum_cache_size_bytes_ > free_ram) {
 		cout << endl <<" WARNING: Maximum cache size larger than free RAM available" << endl;
 		cout << " Free RAM " << free_ram / 1000000 << "MB" << endl;
 	}
-
-	cout << "Maximum cache size:\t"
-			<< statistics_.maximum_cache_size_bytes_ / 1000000 << " MB" << endl
-			<< endl;
+  if(!config_.quiet)
+    cout << "Maximum cache size:\t"
+        << statistics_.maximum_cache_size_bytes_ / 1000000 << " MB" << endl
+        << endl;
 
 	assert(!statistics_.cache_full());
 

--- a/src/component_cache.h
+++ b/src/component_cache.h
@@ -17,12 +17,14 @@
 #include "component_types/component.h"
 
 #include "stack.h"
+#include "solver_config.h"
 
 
 class ComponentCache {
 public:
 
-  ComponentCache(DataAndStatistics &statistics);
+  ComponentCache(DataAndStatistics &statistics,
+                 SolverConfiguration& config);
 
   ~ComponentCache() {
    // debug_dump_data();
@@ -163,6 +165,7 @@ private:
   unsigned table_size_mask_;
 
   DataAndStatistics &statistics_;
+  SolverConfiguration &config_;
 
   unsigned long my_time_ = 0;
 };

--- a/src/component_management.h
+++ b/src/component_management.h
@@ -29,7 +29,7 @@ class ComponentManager {
 public:
   ComponentManager(SolverConfiguration &config, DataAndStatistics &statistics,
         LiteralIndexedVector<TriValue> & lit_values) :
-        config_(config), statistics_(statistics), cache_(statistics),
+        config_(config), statistics_(statistics), cache_(statistics, config),
         ana_(statistics,lit_values) {
   }
 


### PR DESCRIPTION
This is a fix to issue #2 proposed by @ChrisJefferson that quiet mode is not quiet and prevents some cache information.  It shares a reference to the SolverConfiguration object so they can see quiet mode.