### PR TITLE
Removing the Release Directory Directly in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,13 @@ Options:
 Building
 =========
 
-It suffices to change to the ./Release subdirectory and run
+It suffices to run the bash script:
 
-make
+`setupdev.sh`
+
+Then change into the subdirectory "./build/Release/" and run:
+
+`make`
 
 
 NOTE:


### PR DESCRIPTION
Changes to README to address issue #4 raised by @loah86 that the README is out of date.  Minor changes only that also recommends running the bash script.