### PR TITLE
Fixing bug with log(0) called

### DIFF
--- a/src/component_types/base_packed_component.cpp
+++ b/src/component_types/base_packed_component.cpp
@@ -20,10 +20,19 @@ unsigned BasePackedComponent::_data_size_mask = 0;
 void BasePackedComponent::adjustPackSize(unsigned int maxVarId,
     unsigned int maxClId) {
 
-  _bits_per_variable = log2(maxVarId) + 1;
-  _bits_per_clause   = log2(maxClId) + 1;
+  if (maxVarId > 0) {
+    _bits_per_variable = log2(maxVarId) + 1;
+    _bits_per_clause   = log2(maxClId) + 1;
+  } else {
+    _bits_per_variable = 1;
+    _bits_per_clause   = 1;
+  }
 
-  _bits_of_data_size = log2(maxVarId + maxClId) + 1;
+  if (maxVarId + maxClId > 0) {
+    _bits_of_data_size = log2(maxVarId + maxClId) + 1;
+  } else {
+    _bits_of_data_size = 1;
+  }
 
   _variable_mask = _clause_mask = _data_size_mask = 0;
   for (unsigned int i = 0; i < _bits_per_variable; i++)


### PR DESCRIPTION
This fixes a `log(0)` issue with CNF:

```
p cnf 4 4
-2 4 0
3 4 0
-3 -4 0
3 -4 0
```

That otherwise gives:

```
soos@tiresias:count_fuzzer$ ../sharpSAT/build/sharpSAT a.cnf 
Solving a.cnf
variables (all/used/free):      4/4/0
clauses (all/long/binary/unit): 4/0/4/0

Preprocessing .. DONE
variables (all/used/free):      1/0/1
clauses (all/long/binary/unit): 0/0/0/0
56 16
sharpSAT: /home/soos/development/sat_solvers/sharpSAT/src/component_types/difference_packed_component.h:119: DifferencePackedComponent::DifferencePackedComponent(Component&): Assertion `(data_size >> bits_of_data_size()) == 0' failed.
Aborted (core dumped)
```

@latower for visibility