### PR TITLE
Fix type issue and add windows support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 2.8)
-project (SHARPSAT) 
+cmake_minimum_required (VERSION 3.5)
+project (SHARPSAT)
 
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -std=c++11 -Wall")
 
@@ -26,4 +26,4 @@ find_library(GMPXX_LIB gmpxx)
 add_subdirectory(src)
 
 add_executable (sharpSAT src/main.cpp)
-target_link_libraries (sharpSAT libsharpSAT ${GMP_LIB} ${GMPXX_LIB}) 
+target_link_libraries (sharpSAT libsharpSAT ${GMP_LIB} ${GMPXX_LIB})

--- a/setupdev.sh
+++ b/setupdev.sh
@@ -7,16 +7,18 @@ mkdir Release
 cd Release
 
 cmake -DCMAKE_BUILD_TYPE=Release ../..
+# cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DGMP_INCLUDE_DIR=C:\gmp\include -DGMP_LIB=C:\gmp\lib\libgmp.a -DGMPXX_LIB=C:\gmp\lib\libgmpxx.a ../..
 
 cd ..
 mkdir Debug
 cd Debug
 
 cmake -DCMAKE_BUILD_TYPE=Debug ../..
+# cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DGMP_INCLUDE_DIR=C:\gmp\include -DGMP_LIB=C:\gmp\lib\libgmp.a -DGMPXX_LIB=C:\gmp\lib\libgmpxx.a ../..
 
 cd ..
 mkdir Profiling
 cd Profiling
 
 cmake -DCMAKE_BUILD_TYPE=Profiling ../..
-
+# cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Profiling -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DGMP_INCLUDE_DIR=C:\gmp\include -DGMP_LIB=C:\gmp\lib\libgmp.a -DGMPXX_LIB=C:\gmp\lib\libgmpxx.a ../..

--- a/src/component_types/difference_packed_component.h
+++ b/src/component_types/difference_packed_component.h
@@ -12,6 +12,7 @@
 #include "component.h"
 
 #include <math.h>
+#include <cstdint>
 
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,11 @@
 #include <string>
 
 #include <sys/time.h>
+
+#if defined(__linux__) || defined(__APPLE__)
 #include <sys/resource.h>
+#endif
+//#include <sys/resource.h>
 
 using namespace std;
 


### PR DESCRIPTION
Hello,

I’ve made two sets of changes, as described in the title.

The first commit addresses a data type issue that was causing build errors. The code appeared to be missing an appropriate header for fixed-width integer types. By including <cstdint>, I resolved the following compilation error:

```
(venv) aj@aj-PC:/tmp/sharpSAT/build/Release$ make
[  7%] Building CXX object src/component_types/CMakeFiles/component_types.dir/base_packed_component.cpp.o
[ 14%] Building CXX object src/component_types/CMakeFiles/component_types.dir/component_archetype.cpp.o
In file included from /tmp/sharpSAT/src/component_types/cacheable_component.h:16,
                 from /tmp/sharpSAT/src/component_types/component_archetype.h:16,
                 from /tmp/sharpSAT/src/component_types/component_archetype.cpp:8:
/tmp/sharpSAT/src/component_types/difference_packed_component.h: In member function ‘unsigned int DifferencePackedComponent::num_variables() const’:
/tmp/sharpSAT/src/component_types/difference_packed_component.h:27:5: error: ‘uint64_t’ was not declared in this scope
   27 |     uint64_t *p = (uint64_t *) data_;
      |     ^~~~~~~~
/tmp/sharpSAT/src/component_types/difference_packed_component.h:15:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
   14 | #include <math.h>
  +++ |+#include <cstdint>
   15 | 
/tmp/sharpSAT/src/component_types/difference_packed_component.h:27:15: error: ‘p’ was not declared in this scope
   27 |     uint64_t *p = (uint64_t *) data_;
      |               ^
/tmp/sharpSAT/src/component_types/difference_packed_component.h:27:30: error: expected primary-expression before ‘)’ token
   27 |     uint64_t *p = (uint64_t *) data_;
      |                              ^
/tmp/sharpSAT/src/component_types/difference_packed_component.h:28:53: error: expected ‘;’ before ‘variable_mask’
   28 |     return (*p >> bits_of_data_size()) & (uint64_t) variable_mask();
      |                                                     ^~~~~~~~~~~~~
make[2]: *** [src/component_types/CMakeFiles/component_types.dir/build.make:90: src/component_types/CMakeFiles/component_types.dir/component_archetype.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:170: src/component_types/CMakeFiles/component_types.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```


The second commit includes changes that enable the code to compile on Windows. I have successfully built the project on Windows 10, and the changes do not affect compilation on Linux-based systems (I specifically tested it on Ubuntu 24.04).